### PR TITLE
Fixed session detection

### DIFF
--- a/Nextras/MailPanel/SessionMailer.php
+++ b/Nextras/MailPanel/SessionMailer.php
@@ -114,7 +114,7 @@ class SessionMailer implements IMailer
 
 	private function canAccessSession()
 	{
-		return $this->session->isStarted() || !(!headers_sent() && ob_get_level() && ob_get_length());
+		return $this->session->isStarted();
 	}
 
 }


### PR DESCRIPTION
The detection didn't work correctly, I still got "Warning: session_start(): Cannot send session cache limiter - headers already sent (output started at ...".
