### PR TITLE
Fix for Nette 2.2 (nette-panel renamed to tracy-panel).

### DIFF
--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -7,26 +7,26 @@
  * @licence New BSD
  *}
 <style>
-	.nette-panel[id~=MailPanel] {
+	.nette-panel[id~=MailPanel], .tracy-panel[id~=MailPanel] {
 		text-align: left;
 		overflow: auto;
 		max-height: 600px;
 	}
-	.nette-panel .mail-container {
+	.nette-panel .mail-container, .tracy-panel .mail-container {
 		margin-bottom: 10px !important;
 		width: 540px;
 	}
-	.nette-panel .mail-body {
+	.nette-panel .mail-body, .tracy-panel .mail-body {
 		border: 1px solid #A7A7A7 !important;
 		padding: 10px !important;
 		background: #FFF !important;
 		width: 100%;
 		height: auto;
 	}
-	.nette-panel a.delete-link {
+	.nette-panel a.delete-link, .tracy-panel a.delete-link {
 		float: right;
 	}
-	.nette-panel a.delete-all-link {
+	.nette-panel a.delete-all-link, .tracy-panel a.delete-all-link {
 		float: right;
 		margin: 15px 5px 0 0 !important;
 	}

--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -7,26 +7,26 @@
  * @licence New BSD
  *}
 <style>
-	.nette-panel[id~=MailPanel], .tracy-panel[id~=MailPanel] {
+	.tracy-panel[id~=MailPanel] {
 		text-align: left;
 		overflow: auto;
 		max-height: 600px;
 	}
-	.nette-panel .mail-container, .tracy-panel .mail-container {
+	.tracy-panel .mail-container {
 		margin-bottom: 10px !important;
 		width: 540px;
 	}
-	.nette-panel .mail-body, .tracy-panel .mail-body {
+	.tracy-panel .mail-body {
 		border: 1px solid #A7A7A7 !important;
 		padding: 10px !important;
 		background: #FFF !important;
 		width: 100%;
 		height: auto;
 	}
-	.nette-panel a.delete-link, .tracy-panel a.delete-link {
+	.tracy-panel a.delete-link {
 		float: right;
 	}
-	.nette-panel a.delete-all-link, .tracy-panel a.delete-all-link {
+	.tracy-panel a.delete-all-link {
 		float: right;
 		margin: 15px 5px 0 0 !important;
 	}


### PR DESCRIPTION
CSS class `nette-panel` has been renamed to `tracy-panel`. This commit will fixes the problem with unmatching styles and keeps backward compatibility (might be removed, not sure here).