### PR TITLE
Close iframe document after data are written

### DIFF
--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -98,7 +98,9 @@
 						<iframe class="mail-body" id="mail-body-{$hash}-{$index}"></iframe>
 						<script type="text/javascript">
 							var mailContent = '<base target="_parent" />' + {$mailContent};
-							document.getElementById('mail-body-' + {$hash} + '-{$index}').contentWindow.document.write(mailContent);
+							var iframeDocument = document.getElementById('mail-body-' + {$hash} + '-{$index}').contentWindow.document;
+							iframeDocument.write(mailContent);
+							iframeDocument.close();
 						</script>
 					</td>
 				</tr>


### PR DESCRIPTION
Without this my browser (Chrome 43) keeps waiting for localhost (+ spinner animation in tab) as it probably expects some more data to come.
It doesn't affect functionality but it's rather annoying.