### PR TITLE
Add message source display + fix empty text with plain text emails with attachment

### DIFF
--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -23,7 +23,8 @@
 		height: auto;
 		box-sizing: padding-box;
 	}
-	.tracy-panel[id$=MailPanel] a.delete-link {
+	.tracy-panel[id$=MailPanel] a.delete-link,
+	.tracy-panel[id$=MailPanel] a.source-link {
 		float: right;
 	}
 </style>
@@ -87,12 +88,15 @@
 				{/if}
 				{* Little magic here. Create iframe and then render message into it (needed because HTML messages) *}
 				{var $mailContent = $mail->getHtmlBody()}
-				{if $mailContent == NULL}
-					{var $mailContent = '<pre style="font-family:serif">' . $mail->getBody() . '</pre>'}
-					<tr><th colspan="2">Plaintext e-mail</th></tr>
-				{else}
-					<tr><th colspan="2">HTML e-mail</th></tr>
-				{/if}
+				<tr><th colspan="2">
+					{if $mailContent == NULL}
+						{var $mailContent = '<pre style="font-family:serif">' . $mail->getBody() . '</pre>'}
+						Plaintext e-mail
+					{else}
+						HTML e-mail
+					{/if}
+					<a class="source-link" target="_blank" href="{$baseUrl}?mail-panel=source&mail-panel-mail={$index}">Source</a>
+				</th></tr>
 				<tr>
 					<td colspan="2">
 						<iframe class="mail-body" id="mail-body-{$hash}-{$index}"></iframe>

--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -90,7 +90,12 @@
 				{var $mailContent = $mail->getHtmlBody()}
 				<tr><th colspan="2">
 					{if $mailContent == NULL}
-						{var $mailContent = '<pre style="font-family:serif">' . $mail->getBody() . '</pre>'}
+						{if $mail->getAttachments()} {* Workaround: when plain text mail have attachments the text is not in body but in mime part! *}
+							{var $mailContent = '<pre style="font-family:serif">' . \Nextras\MailPanel\MailPanel::extractPlainText($mail) . '</pre>'}
+						{else}
+							{var $mailContent = '<pre style="font-family:serif">' . $mail->getBody() . '</pre>'}
+						{/if}
+
 						Plaintext e-mail
 					{else}
 						HTML e-mail

--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -88,20 +88,21 @@
 				{/if}
 				{* Little magic here. Create iframe and then render message into it (needed because HTML messages) *}
 				{var $mailContent = $mail->getHtmlBody()}
-				<tr><th colspan="2">
-					{if $mailContent == NULL}
-						{if $mail->getAttachments()} {* Workaround: when plain text mail have attachments the text is not in body but in mime part! *}
-							{var $mailContent = '<pre style="font-family:serif">' . \Nextras\MailPanel\MailPanel::extractPlainText($mail) . '</pre>'}
+				<tr>
+					<th colspan="2">
+						{if $mailContent == NULL}
+							{if $mail->getAttachments()} {* Workaround: when plain text mail have attachments the text is not in body but in mime part! *}
+								{var $mailContent = '<pre style="font-family:serif">' . \Nextras\MailPanel\MailPanel::extractPlainText($mail) . '</pre>'}
+							{else}
+								{var $mailContent = '<pre style="font-family:serif">' . $mail->getBody() . '</pre>'}
+							{/if}
+							Plaintext e-mail
 						{else}
-							{var $mailContent = '<pre style="font-family:serif">' . $mail->getBody() . '</pre>'}
+							HTML e-mail
 						{/if}
-
-						Plaintext e-mail
-					{else}
-						HTML e-mail
-					{/if}
-					<a class="source-link" target="_blank" href="{$baseUrl}?mail-panel=source&mail-panel-mail={$index}">Source</a>
-				</th></tr>
+						<a class="source-link" target="_blank" href="{$baseUrl}?mail-panel=source&mail-panel-mail={$index}">Source</a>
+					</th>
+				</tr>
 				<tr>
 					<td colspan="2">
 						<iframe class="mail-body" id="mail-body-{$hash}-{$index}"></iframe>
@@ -118,7 +119,7 @@
 					<th>Attachments</th>
 					<td>
 						{foreach $attachments as $i => $row}
-							<a target="_blank" href="{$baseUrl}?mail-panel-attachment={$i}&mail-panel-mail={$index}">{$i + 1}. {$row->getHeader('Content-Type')}</a>{sep}<br>{/sep}
+							<a target="_blank" href="{$baseUrl}?mail-panel-attachment={$i}&amp;mail-panel-mail={$index}">{$i + 1}. {$row->getHeader('Content-Type')}</a>{sep}<br>{/sep}
 						{/foreach}
 					</td>
 				</tr>

--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -24,8 +24,10 @@
 		box-sizing: padding-box;
 	}
 	.tracy-panel[id$=MailPanel] a.delete-link,
+	.tracy-panel[id$=MailPanel] a.detail-link,
 	.tracy-panel[id$=MailPanel] a.source-link {
 		float: right;
+		margin-left: 10px !important;
 	}
 </style>
 
@@ -86,21 +88,17 @@
 						</td>
 					</tr>
 				{/if}
-				{* Little magic here. Create iframe and then render message into it (needed because HTML messages) *}
-				{var $mailContent = $mail->getHtmlBody()}
+				{* Prepare mail content for display *}
+				{capture $mailContent}{include MailPanel_body.latte, message => $mail}{/capture}
 				<tr>
 					<th colspan="2">
-						{if $mailContent == NULL}
-							{if $mail->getAttachments()} {* Workaround: when plain text mail have attachments the text is not in body but in mime part! *}
-								{var $mailContent = '<pre style="font-family:serif">' . \Nextras\MailPanel\MailPanel::extractPlainText($mail) . '</pre>'}
-							{else}
-								{var $mailContent = '<pre style="font-family:serif">' . $mail->getBody() . '</pre>'}
-							{/if}
+						{if \Nextras\MailPanel\MailPanel::isPlainText($mail)}
 							Plaintext e-mail
 						{else}
 							HTML e-mail
 						{/if}
-						<a class="source-link" target="_blank" href="{$baseUrl}?mail-panel=source&mail-panel-mail={$index}">Source</a>
+						<a class="source-link" target="_blank" href="{$baseUrl}?mail-panel=source&amp;mail-panel-mail={$index}">Source</a>
+						<a class="detail-link" target="_blank" href="{$baseUrl}?mail-panel=detail&amp;mail-panel-mail={$index}">Open</a>
 					</th>
 				</tr>
 				<tr>

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -42,15 +42,17 @@ class MailPanel extends Object implements IBarPanel
 		$this->tempDir = $tempDir;
 
 		$query = $request->getQuery("mail-panel");
+		$mailId = $request->getQuery("mail-panel-mail");
 
-		if ($query === 'delete') {
+		if ($query === 'source' && is_numeric($mailId)) {
+			$this->handleSource($mailId);
+		} elseif ($query === 'delete') {
 			$this->handleDeleteAll();
 		} elseif (is_numeric($query)) {
 			$this->handleDelete($query);
 		}
 
 		$attachment = $request->getQuery("mail-panel-attachment");
-		$mailId = $request->getQuery("mail-panel-mail");
 
 		if ($attachment !== NULL && $mailId !== NULL) {
 			$this->handleAttachment($attachment, $mailId);
@@ -141,6 +143,18 @@ class MailPanel extends Object implements IBarPanel
 		}
 		header('Content-Type: ' . $attachment->getHeader('Content-Type'));
 		echo $attachment->getBody();
+		exit;
+	}
+
+	private function handleSource($mailId)
+	{
+		/** @var Message[] $list */
+		$list = $this->mailer->getMessages($this->messagesLimit);
+		if (!isset($list[$mailId])) {
+			return;
+		}
+		header('Content-Type: text/plain');
+		echo $list[$mailId]->getEncodedMessage();
 		exit;
 	}
 

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -4,7 +4,9 @@ namespace Nextras\MailPanel;
 
 use Nette\Http\Request;
 use Nette\Mail\Message;
+use Nette\Mail\MimePart;
 use Nette\Object;
+use Nette\Utils\Strings;
 use Tracy\IBarPanel;
 use Latte;
 
@@ -156,6 +158,19 @@ class MailPanel extends Object implements IBarPanel
 		header('Content-Type: text/plain');
 		echo $list[$mailId]->getEncodedMessage();
 		exit;
+	}
+
+	public static function extractPlainText(Message $message)
+	{
+		$propertyReflection = $message->getReflection()->getParentClass()->getProperty('parts');
+		$propertyReflection->setAccessible(true);
+		$parts = $propertyReflection->getValue($message);
+		/** @var MimePart $part */
+		foreach ($parts as $part) {
+			if (Strings::startsWith($part->getHeader('Content-Type'), 'text/plain') && $part->getHeader('Content-Transfer-Encoding') !== 'base64') { // Take first available plain text
+				return $part->getBody();
+			}
+		}
 	}
 
 }

--- a/src/MailPanel_body.latte
+++ b/src/MailPanel_body.latte
@@ -1,0 +1,11 @@
+{* Little magic here. Create iframe and then render message into it (needed because HTML messages) *}
+{var $mailContent = $message->getHtmlBody()}
+{if $mailContent === NULL}
+    {if $message->getAttachments()}
+        <pre style="font-family:serif">{\Nextras\MailPanel\MailPanel::extractPlainText($message)}</pre>
+    {else}
+        <pre style="font-family:serif">{$message->getBody()}</pre>
+    {/if}
+{else}
+    {$mailContent|noEscape}
+{/if}


### PR DESCRIPTION
Sometime it is useful to see complete message including all headers. This pull request adds this functionality via "Source" link which opens a new blank window with message source.