### PR TITLE
Enable Nette v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+# IDE
+/.idea
+
 /composer.lock
 /vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 php:
-  - 7.0
   - 7.1
   - 7.2
-  - master
+  - 7.3
 
 env:
   - dependencies=lowest

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6",
-		"nette/mail":   "~2.4",
-		"nette/utils":  "~2.4",
-		"nette/http":   "~2.4",
-		"latte/latte":  "~2.4",
-		"tracy/tracy":  "~2.4"
+		"php": ">=7.1",
+		"nette/mail":   "~2.4|^3.0",
+		"nette/utils":  "~2.4|^3.0",
+		"nette/http":   "~2.4|^3.0",
+		"latte/latte":  "~2.4|^3.0",
+		"tracy/tracy":  "~2.4|^2.6.2"
 	},
 	"require-dev": {
 		"phpstan/phpstan-shim": "~0.9.1",

--- a/src/FileMailer.php
+++ b/src/FileMailer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * This file is part of the Nextras\MailPanel library.
@@ -29,10 +30,7 @@ class FileMailer implements IPersistentMailer
 	private $files;
 
 
-	/**
-	 * @param string $tempDir
-	 */
-	public function __construct($tempDir)
+	public function __construct(string $tempDir)
 	{
 		$this->tempDir = $tempDir;
 	}
@@ -40,11 +38,8 @@ class FileMailer implements IPersistentMailer
 
 	/**
 	 * Stores mail to a file.
-	 *
-	 * @param  Message $message
-	 * @return void
 	 */
-	public function send(Message $message)
+	public function send(Message $message): void
 	{
 		// get message with generated html instead of set FileTemplate etc
 		$ref = new \ReflectionMethod('Nette\Mail\Message', 'build');
@@ -64,7 +59,7 @@ class FileMailer implements IPersistentMailer
 	/**
 	 * @inheritdoc
 	 */
-	public function getMessageCount()
+	public function getMessageCount(): int
 	{
 		return count($this->findFiles());
 	}
@@ -73,7 +68,7 @@ class FileMailer implements IPersistentMailer
 	/**
 	 * @inheritDoc
 	 */
-	public function getMessage($messageId)
+	public function getMessage(string $messageId): Message
 	{
 		$files = $this->findFiles();
 		if (!isset($files[$messageId])) {
@@ -87,7 +82,7 @@ class FileMailer implements IPersistentMailer
 	/**
 	 * @inheritdoc
 	 */
-	public function getMessages($limit)
+	public function getMessages(int $limit): array
 	{
 		$files = array_slice($this->findFiles(), 0, $limit, TRUE);
 		$mails = array_map(array($this, 'readMail'), $files);
@@ -99,7 +94,7 @@ class FileMailer implements IPersistentMailer
 	/**
 	 * @inheritdoc
 	 */
-	public function deleteOne($messageId)
+	public function deleteOne(string $messageId): void
 	{
 		$files = $this->findFiles();
 		if (!isset($files[$messageId])) {
@@ -113,7 +108,7 @@ class FileMailer implements IPersistentMailer
 	/**
 	 * @inheritdoc
 	 */
-	public function deleteAll()
+	public function deleteAll(): void
 	{
 		foreach ($this->findFiles() as $file) {
 			FileSystem::delete($file);
@@ -124,7 +119,7 @@ class FileMailer implements IPersistentMailer
 	/**
 	 * @return string[]
 	 */
-	private function findFiles()
+	private function findFiles(): array
 	{
 		if ($this->files === NULL) {
 			$this->files = array();
@@ -139,11 +134,7 @@ class FileMailer implements IPersistentMailer
 	}
 
 
-	/**
-	 * @param  string $path
-	 * @return Nette\Mail\Message
-	 */
-	private function readMail($path)
+	private function readMail(string $path): Message
 	{
 		$content = file_get_contents($path);
 		if ($content === FALSE) {

--- a/src/IPersistentMailer.php
+++ b/src/IPersistentMailer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * This file is part of the Nextras\MailPanel library.
@@ -9,6 +10,7 @@
 namespace Nextras\MailPanel;
 
 use Nette;
+use Nette\Mail\Message;
 
 
 /**
@@ -16,35 +18,20 @@ use Nette;
  */
 interface IPersistentMailer extends Nette\Mail\IMailer
 {
-	/**
-	 * @return int
-	 */
-	public function getMessageCount();
+	public function getMessageCount(): int;
+
+
+	public function getMessage(string $messageId): Message;
 
 
 	/**
-	 * @param  string $messageId
-	 * @return Nette\Mail\Message
-	 */
-	public function getMessage($messageId);
-
-
-	/**
-	 * @param  int $limit
 	 * @return Nette\Mail\Message[]
 	 */
-	public function getMessages($limit);
+	public function getMessages(int $limit): array;
 
 
-	/**
-	 * @param  string $messageId
-	 * @return void
-	 */
-	public function deleteOne($messageId);
+	public function deleteOne(string $messageId): void;
 
 
-	/**
-	 * @return void
-	 */
-	public function deleteAll();
+	public function deleteAll(): void;
 }

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * This file is part of the Nextras\MailPanel library.
@@ -43,14 +44,7 @@ class MailPanel implements IBarPanel
 	/** @var Latte\Engine */
 	private $latte;
 
-
-	/**
-	 * @param string|NULL  $tempDir
-	 * @param Http\IRequest $request
-	 * @param IMailer      $mailer
-	 * @param int          $messagesLimit
-	 */
-	public function __construct($tempDir, Http\IRequest $request, IMailer $mailer, $messagesLimit = self::DEFAULT_COUNT)
+	public function __construct(?string $tempDir, Http\IRequest $request, IMailer $mailer, int $messagesLimit = self::DEFAULT_COUNT)
 	{
 		if (!$mailer instanceof IPersistentMailer) {
 			return;
@@ -67,9 +61,8 @@ class MailPanel implements IBarPanel
 
 	/**
 	 * Renders HTML code for custom tab
-	 * @return string
 	 */
-	public function getTab()
+	public function getTab(): string
 	{
 		if ($this->mailer === NULL) {
 			return '';
@@ -93,7 +86,7 @@ class MailPanel implements IBarPanel
 	/**
 	 * @inheritdoc
 	 */
-	public function getPanel()
+	public function getPanel(): string
 	{
 		if ($this->mailer === NULL) {
 			return '';
@@ -109,11 +102,8 @@ class MailPanel implements IBarPanel
 
 	/**
 	 * Run-time link helper
-	 * @param  string $action
-	 * @param  array  $params
-	 * @return string
 	 */
-	public function getLink($action, array $params)
+	public function getLink(string $action, array $params): string
 	{
 		$url = $this->request->getUrl();
 		$baseUrl = substr($url->getPath(), strrpos($url->getScriptPath(), '/') + 1);
@@ -128,10 +118,7 @@ class MailPanel implements IBarPanel
 	}
 
 
-	/**
-	 * @return Latte\Engine
-	 */
-	private function getLatte()
+	private function getLatte(): Latte\Engine
 	{
 		if (!isset($this->latte)) {
 			$this->latte = new Latte\Engine();
@@ -175,10 +162,7 @@ class MailPanel implements IBarPanel
 	}
 
 
-	/**
-	 * @return void
-	 */
-	private function tryHandleRequest()
+	private function tryHandleRequest(): void
 	{
 		if (Debugger::$productionMode !== FALSE) {
 			return;
@@ -206,11 +190,7 @@ class MailPanel implements IBarPanel
 	}
 
 
-	/**
-	 * @param  string $messageId
-	 * @return void
-	 */
-	private function handleDetail($messageId)
+	private function handleDetail(string $messageId): void
 	{
 		$message = $this->mailer->getMessage($messageId);
 
@@ -220,11 +200,7 @@ class MailPanel implements IBarPanel
 	}
 
 
-	/**
-	 * @param  string $messageId
-	 * @return void
-	 */
-	private function handleSource($messageId)
+	private function handleSource(string $messageId): void
 	{
 		$message = $this->mailer->getMessage($messageId);
 
@@ -234,12 +210,7 @@ class MailPanel implements IBarPanel
 	}
 
 
-	/**
-	 * @param  string $messageId
-	 * @param  int    $attachmentId
-	 * @return void
-	 */
-	private function handleAttachment($messageId, $attachmentId)
+	private function handleAttachment(string $messageId, int $attachmentId): void
 	{
 		$attachments = $this->mailer->getMessage($messageId)->getAttachments();
 		if (!isset($attachments[$attachmentId])) {
@@ -257,31 +228,21 @@ class MailPanel implements IBarPanel
 	}
 
 
-	/**
-	 * @param  string $id
-	 * @return void
-	 */
-	private function handleDeleteOne($id)
+	private function handleDeleteOne(string $id): void
 	{
 		$this->mailer->deleteOne($id);
 		$this->returnBack();
 	}
 
 
-	/**
-	 * @return void
-	 */
-	private function handleDeleteAll()
+	private function handleDeleteAll(): void
 	{
 		$this->mailer->deleteAll();
 		$this->returnBack();
 	}
 
 
-	/**
-	 * @return void
-	 */
-	private function returnBack()
+	private function returnBack(): void
 	{
 		$currentUrl = $this->request->getUrl();
 		$refererUrl = $this->request->getHeader('referer');

--- a/src/SessionMailer.php
+++ b/src/SessionMailer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * This file is part of the Nextras\MailPanel library.
@@ -29,12 +30,7 @@ class SessionMailer implements IPersistentMailer
 	private $sessionSection;
 
 
-	/**
-	 * @param Session $session
-	 * @param int     $limit
-	 * @param string  $sectionName
-	 */
-	public function __construct(Session $session, $limit = 100, $sectionName = __CLASS__)
+	public function __construct(Session $session, int $limit = 100, string $sectionName = __CLASS__)
 	{
 		$this->limit = $limit;
 		$this->session = $session;
@@ -44,11 +40,8 @@ class SessionMailer implements IPersistentMailer
 
 	/**
 	 * Store mails to sessions.
-	 *
-	 * @param  Message $message
-	 * @return void
 	 */
-	public function send(Message $message)
+	public function send(Message $message) : void
 	{
 		// get message with generated html instead of set FileTemplate etc
 		$ref = new \ReflectionMethod('Nette\Mail\Message', 'build');
@@ -69,7 +62,7 @@ class SessionMailer implements IPersistentMailer
 	/**
 	 * @inheritdoc
 	 */
-	public function getMessageCount()
+	public function getMessageCount(): int
 	{
 		return count($this->getMessages());
 	}
@@ -78,7 +71,7 @@ class SessionMailer implements IPersistentMailer
 	/**
 	 * @inheritDoc
 	 */
-	public function getMessage($messageId)
+	public function getMessage(string $messageId): Message
 	{
 		$this->requireSessions();
 
@@ -93,7 +86,7 @@ class SessionMailer implements IPersistentMailer
 	/**
 	 * @inheritdoc
 	 */
-	public function getMessages($limit = NULL)
+	public function getMessages(int $limit = NULL): array
 	{
 		if ($this->session->isStarted() && isset($this->sessionSection->messages)) {
 			$messages = $this->sessionSection->messages;
@@ -108,7 +101,7 @@ class SessionMailer implements IPersistentMailer
 	/**
 	 * @inheritdoc
 	 */
-	public function deleteOne($messageId)
+	public function deleteOne(string $messageId): void
 	{
 		$this->requireSessions();
 		if (!isset($this->sessionSection->messages[$messageId])) {
@@ -122,7 +115,7 @@ class SessionMailer implements IPersistentMailer
 	/**
 	 * @inheritdoc
 	 */
-	public function deleteAll()
+	public function deleteAll(): void
 	{
 		$this->sessionSection->messages = array();
 	}
@@ -130,18 +123,14 @@ class SessionMailer implements IPersistentMailer
 
 	/**
 	 * Return limit of stored mails
-	 * @return int
 	 */
-	public function getLimit()
+	public function getLimit(): int
 	{
 		return $this->limit;
 	}
 
 
-	/**
-	 * @return void
-	 */
-	private function requireSessions()
+	private function requireSessions(): void
 	{
 		if (!$this->session->isStarted()) {
 			throw new \RuntimeException('Session is not started, start session or use FileMailer instead.');


### PR DESCRIPTION
BC Break? Yes

It relaxes dependencies to enable Nette v3 dependencies. But also introduce strict return types into IPersistentMailer (IMailer introduce strict signature on the method `send`). Therefore minimal runtime is set to 7.1.