### PR TITLE
Rename Nette\Mail\IMailer to Nette\Mail\Mailer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	],
 	"require": {
 		"php": "~7.1 || ~8.0",
-		"nette/mail":   "~3.0",
+		"nette/mail":   "~3.1",
 		"nette/utils":  "~3.0",
 		"nette/http":   "~3.0",
 		"latte/latte":  "~2.5",

--- a/readme.md
+++ b/readme.md
@@ -28,19 +28,19 @@ Nextras Mail Panel is an extension for [Nette Framework](https://nette.org) whic
 
 	services:
 		nette.mailer:
-			class: Nette\Mail\IMailer
+			class: Nette\Mail\Mailer
 			factory: Nextras\MailPanel\FileMailer(%tempDir%/mail-panel-mails)
 	```
 
 
 ### Usage
 
-Messages has to be sent by injected instance of `Nette\Mail\IMailer`.
+Messages has to be sent by injected instance of `Nette\Mail\Mailer`.
 
 ```php
 class ExamplePresenter extends BasePresenter
 {
-	/** @var Nette\Mail\IMailer @inject */
+	/** @var Nette\Mail\Mailer @inject */
 	public $mailer;
 
 

--- a/src/IPersistentMailer.php
+++ b/src/IPersistentMailer.php
@@ -15,7 +15,7 @@ use Nette\Mail\Message;
 /**
  * Mailer which persists sent mails.
  */
-interface IPersistentMailer extends Nette\Mail\IMailer
+interface IPersistentMailer extends Nette\Mail\Mailer
 {
 	public function getMessageCount(): int;
 

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -11,7 +11,7 @@ namespace Nextras\MailPanel;
 use Latte;
 use Nette;
 use Nette\Http;
-use Nette\Mail\IMailer;
+use Nette\Mail\Mailer;
 use Nette\Mail\MimePart;
 use Nette\Utils\Strings;
 use Tracy\Debugger;
@@ -44,7 +44,7 @@ class MailPanel implements IBarPanel
 	private $latte;
 
 
-	public function __construct(?string $tempDir, Http\IRequest $request, IMailer $mailer, int $messagesLimit = self::DEFAULT_COUNT)
+	public function __construct(?string $tempDir, Http\IRequest $request, Mailer $mailer, int $messagesLimit = self::DEFAULT_COUNT)
 	{
 		if (!$mailer instanceof IPersistentMailer) {
 			return;


### PR DESCRIPTION
As IMailer is deprecated

See: https://github.com/nette/mail/blob/master/src/Mail/Mailer.php