### PR TITLE
Fix html body render

### DIFF
--- a/src/MailPanel.body.latte
+++ b/src/MailPanel.body.latte
@@ -1,5 +1,5 @@
 {* Little magic here. Create iframe and then render message into it (needed because HTML messages) *}
-{if $message->getHtmlBody() !== NULL}
+{if $message->getHtmlBody() !== ''}
 	{$message->getHtmlBody()|noescape}
 {else}
 	<!doctype html>


### PR DESCRIPTION
`getHtmlBody()` always returns string since nette/mail 3.0.0
https://github.com/nette/mail/commit/a162d6feed8fd1914f886b216e5b4b1a785cad8e#diff-24e522f34d7c667386f9e47ed388a2bafb29850aeb94c262d3a0273bf63cca68R244