### PR TITLE
Remove setAccessible call for MimePart property

### DIFF
--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -136,7 +136,6 @@ class MailPanel implements IBarPanel
 
 			$this->latte->addFilter('plainText', function (MimePart $part) {
 				$ref = new \ReflectionProperty('Nette\Mail\MimePart', 'parts');
-				$ref->setAccessible(true);
 
 				$queue = [$part];
 				for ($i = 0; $i < count($queue); $i++) {


### PR DESCRIPTION
Remove accessibility setting for ReflectionProperty in MailPanel since it is no-op since php8.1