### PR TITLE
fix html preview rendering in tracy panel

### DIFF
--- a/src/MailPanel.body.latte
+++ b/src/MailPanel.body.latte
@@ -1,22 +1,2 @@
 {* Little magic here. Create iframe and then render message into it (needed because HTML messages) *}
-{if $message->getHtmlBody() !== ''}
-	{$message->getHtmlBody()|noescape}
-{else}
-	<!doctype html>
-	<meta charset="utf-8">
-	<style>
-		html, body {
-			margin: 0;
-			padding: 0;
-			border: none;
-			font-family: sans-serif;
-			font-size: 12px;
-			white-space: pre;
-		}
-
-		body {
-			padding: 10px;
-		}
-	</style>
-	<body>{$message|plainText}</body>
-{/if}
+{$message|previewHtml|noescape}

--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -108,8 +108,7 @@
 				</tr>
 
 				<tr class="nextras-mail-panel-preview-html tracy-collapsed">
-					{capture $htmlPreview}{include MailPanel.body.latte, message => $message}{/capture}
-					<td colspan="2" data-content="{$htmlPreview}"></td>
+					<td colspan="2" data-content="{$message|previewHtml}"></td>
 				</tr>
 			</table>
 		{/foreach}

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -147,14 +147,6 @@ class MailPanel implements IBarPanel
 				return $this->decodeBody($part);
 			});
 
-			$this->latte->addFilter('htmlBody', function (MimePart $part): string {
-				if ($part instanceof Message && $part->getHtmlBody() !== '') {
-					return $part->getHtmlBody();
-				}
-
-				return $this->findBodyByContentType($part, 'text/html') ?? '';
-			});
-
 			$this->latte->addFilter('previewHtml', function (MimePart $part): string {
 				$htmlBody = $this->extractHtmlBody($part);
 				if ($htmlBody !== '') {
@@ -210,7 +202,9 @@ class MailPanel implements IBarPanel
 	{
 		if ($this->mimePartPartsProperty === null) {
 			$this->mimePartPartsProperty = new \ReflectionProperty(MimePart::class, 'parts');
-			$this->mimePartPartsProperty->setAccessible(true);
+			if (PHP_VERSION_ID < 80100) {
+				$this->mimePartPartsProperty->setAccessible(true);
+			}
 		}
 
 		$parts = $this->mimePartPartsProperty->getValue($part);

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -12,6 +12,7 @@ use Latte;
 use Nette;
 use Nette\Http;
 use Nette\Mail\Mailer;
+use Nette\Mail\Message;
 use Nette\Mail\MimePart;
 use Nette\Utils\Strings;
 use Tracy\Debugger;
@@ -42,6 +43,9 @@ class MailPanel implements IBarPanel
 
 	/** @var Latte\Engine|NULL */
 	private $latte;
+
+	/** @var \ReflectionProperty|NULL */
+	private $mimePartPartsProperty;
 
 
 	public function __construct(?string $tempDir, Http\IRequest $request, Mailer $mailer, int $messagesLimit = self::DEFAULT_COUNT)
@@ -135,26 +139,100 @@ class MailPanel implements IBarPanel
 			});
 
 			$this->latte->addFilter('plainText', function (MimePart $part) {
-				$ref = new \ReflectionProperty('Nette\Mail\MimePart', 'parts');
-
-				$queue = [$part];
-				for ($i = 0; $i < count($queue); $i++) {
-					/** @var MimePart $subPart */
-					foreach ($ref->getValue($queue[$i]) as $subPart) {
-						$contentType = $subPart->getHeader('Content-Type');
-						if (Strings::startsWith($contentType, 'text/plain') && $subPart->getHeader('Content-Transfer-Encoding') !== 'base64') { // Take first available plain text
-							return $subPart->getBody();
-						} elseif (Strings::startsWith($contentType, 'multipart/alternative')) {
-							$queue[] = $subPart;
-						}
-					}
+				$plainText = $this->findBodyByContentType($part, 'text/plain');
+				if ($plainText !== null) {
+					return $plainText;
 				}
 
-				return $part->getBody();
+				return $this->decodeBody($part);
+			});
+
+			$this->latte->addFilter('htmlBody', function (MimePart $part): string {
+				if ($part instanceof Message && $part->getHtmlBody() !== '') {
+					return $part->getHtmlBody();
+				}
+
+				return $this->findBodyByContentType($part, 'text/html') ?? '';
+			});
+
+			$this->latte->addFilter('previewHtml', function (MimePart $part): string {
+				$htmlBody = $this->extractHtmlBody($part);
+				if ($htmlBody !== '') {
+					return $htmlBody;
+				}
+
+				$plainText = $this->findBodyByContentType($part, 'text/plain') ?? $this->decodeBody($part);
+				return '<!doctype html>'
+					. '<meta charset="utf-8">'
+					. '<style>html,body{margin:0;padding:0;border:none;font-family:sans-serif;font-size:12px;white-space:pre;}body{padding:10px;}</style>'
+					. '<body>' . htmlspecialchars($plainText, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</body>';
 			});
 		}
 
 		return $this->latte;
+	}
+
+
+	private function extractHtmlBody(MimePart $part): string
+	{
+		if ($part instanceof Message && $part->getHtmlBody() !== '') {
+			return $part->getHtmlBody();
+		}
+
+		return $this->findBodyByContentType($part, 'text/html') ?? '';
+	}
+
+
+	private function findBodyByContentType(MimePart $part, string $contentTypePrefix): ?string
+	{
+		$queue = [$part];
+		for ($i = 0; $i < count($queue); $i++) {
+			$currentPart = $queue[$i];
+			$contentType = $currentPart->getHeader('Content-Type');
+			if (is_string($contentType) && Strings::startsWith(strtolower($contentType), $contentTypePrefix)) {
+				return $this->decodeBody($currentPart);
+			}
+
+			/** @var MimePart $subPart */
+			foreach ($this->getMimePartParts($currentPart) as $subPart) {
+				$queue[] = $subPart;
+			}
+		}
+
+		return null;
+	}
+
+
+	/**
+	 * @return MimePart[]
+	 */
+	private function getMimePartParts(MimePart $part): array
+	{
+		if ($this->mimePartPartsProperty === null) {
+			$this->mimePartPartsProperty = new \ReflectionProperty(MimePart::class, 'parts');
+			$this->mimePartPartsProperty->setAccessible(true);
+		}
+
+		$parts = $this->mimePartPartsProperty->getValue($part);
+		return is_array($parts) ? $parts : [];
+	}
+
+
+	private function decodeBody(MimePart $part): string
+	{
+		$body = $part->getBody();
+		$transferEncoding = strtolower((string) $part->getHeader('Content-Transfer-Encoding'));
+
+		if ($transferEncoding === MimePart::EncodingQuotedPrintable) {
+			return quoted_printable_decode($body);
+		}
+
+		if ($transferEncoding === MimePart::EncodingBase64) {
+			$decodedBody = base64_decode($body, true);
+			return is_string($decodedBody) ? $decodedBody : $body;
+		}
+
+		return $body;
 	}
 
 

--- a/tests/MailPanelTest.phpt
+++ b/tests/MailPanelTest.phpt
@@ -1,0 +1,152 @@
+<?php declare(strict_types = 1);
+
+use Nette\Http\Request;
+use Nette\Http\UrlScript;
+use Nette\Mail\Message;
+use Nextras\MailPanel\IPersistentMailer;
+use Nextras\MailPanel\MailPanel;
+use Tester\Assert;
+use Tester\Helpers;
+use Tester\TestCase;
+
+require __DIR__ . '/bootstrap.php';
+
+
+class MailPanelTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		Helpers::purge(TEMP_DIR);
+	}
+
+
+	public function testRendersHtmlBodyFromTextHtmlMessageBody(): void
+	{
+		$message = (new Message())
+			->setContentType('text/html', 'UTF-8')
+			->setBody('<h1>Hello from HTML</h1>');
+
+		$output = $this->renderMessageBody($message);
+
+		Assert::contains('<h1>Hello from HTML</h1>', $output);
+		Assert::notContains('&lt;h1&gt;Hello from HTML&lt;/h1&gt;', $output);
+	}
+
+
+	public function testPanelStoresEscapedHtmlPreviewInDataAttribute(): void
+	{
+		$message = (new Message())
+			->setSubject('Panel preview')
+			->setHtmlBody('<h1>Hello from HTML</h1>');
+
+		$panel = $this->createPanel(new ArrayPersistentMailer(['message-id' => $message]));
+		$output = $panel->getPanel();
+
+		Assert::contains('data-content="&lt;h1&gt;Hello from HTML&lt;/h1&gt;"', $output);
+	}
+
+
+	private function renderMessageBody(Message $message): string
+	{
+		$panel = $this->createPanel(new NullPersistentMailer());
+
+		$ref = new ReflectionMethod(MailPanel::class, 'getLatte');
+		$ref->setAccessible(true);
+		$latte = $ref->invoke($panel);
+
+		return $latte->renderToString(__DIR__ . '/../src/MailPanel.body.latte', ['message' => $message]);
+	}
+
+
+	private function createPanel(IPersistentMailer $mailer): MailPanel
+	{
+		return new MailPanel(
+			TEMP_DIR . '/latte',
+			new Request(new UrlScript('http://localhost/index.php')),
+			$mailer,
+		);
+	}
+}
+
+
+class NullPersistentMailer implements IPersistentMailer
+{
+	public function send(Message $message): void
+	{
+	}
+
+
+	public function getMessageCount(): int
+	{
+		return 0;
+	}
+
+
+	public function getMessage(string $messageId): Message
+	{
+		throw new RuntimeException('No messages available.');
+	}
+
+
+	public function getMessages(int $limit): array
+	{
+		return [];
+	}
+
+
+	public function deleteOne(string $messageId): void
+	{
+	}
+
+
+	public function deleteAll(): void
+	{
+	}
+}
+
+
+class ArrayPersistentMailer implements IPersistentMailer
+{
+	/**
+	 * @param Message[] $messages
+	 */
+	public function __construct(
+		private array $messages,
+	) {
+	}
+
+
+	public function send(Message $message): void
+	{
+	}
+
+
+	public function getMessageCount(): int
+	{
+		return count($this->messages);
+	}
+
+
+	public function getMessage(string $messageId): Message
+	{
+		return $this->messages[$messageId];
+	}
+
+
+	public function getMessages(int $limit): array
+	{
+		return array_slice($this->messages, 0, $limit, true);
+	}
+
+
+	public function deleteOne(string $messageId): void
+	{
+	}
+
+
+	public function deleteAll(): void
+	{
+	}
+}
+
+(new MailPanelTest)->run();


### PR DESCRIPTION
This fixes HTML preview rendering in the Tracy panel.

Problem:
- some emails were shown as source text in "Preview HTML" even though the email contained a valid `text/html` part

What changed:
- switched preview generation to use a dedicated `previewHtml` filter
- extract HTML robustly from MIME parts (with decoding)
- keep "Open" and "Preview HTML" rendering consistent
- added regression tests

Fixes #29