### PR TITLE
Fix HTML preview rendering in Tracy panel

### DIFF
--- a/src/MailPanel.body.latte
+++ b/src/MailPanel.body.latte
@@ -1,22 +1,2 @@
 {* Little magic here. Create iframe and then render message into it (needed because HTML messages) *}
-{if $message->getHtmlBody() !== ''}
-	{$message->getHtmlBody()|noescape}
-{else}
-	<!doctype html>
-	<meta charset="utf-8">
-	<style>
-		html, body {
-			margin: 0;
-			padding: 0;
-			border: none;
-			font-family: sans-serif;
-			font-size: 12px;
-			white-space: pre;
-		}
-
-		body {
-			padding: 10px;
-		}
-	</style>
-	<body>{$message|plainText}</body>
-{/if}
+{$message|previewHtml|noescape}

--- a/src/MailPanel.body.latte
+++ b/src/MailPanel.body.latte
@@ -1,2 +1,2 @@
-{* Little magic here. Create iframe and then render message into it (needed because HTML messages) *}
+{* Render a standalone HTML preview document or fragment. *}
 {$message|previewHtml|noescape}

--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -108,8 +108,7 @@
 				</tr>
 
 				<tr class="nextras-mail-panel-preview-html tracy-collapsed">
-					{capture $htmlPreview}{include MailPanel.body.latte, message => $message}{/capture}
-					<td colspan="2" data-content="{$htmlPreview}"></td>
+					<td colspan="2" data-content="{$message|previewHtml}"></td>
 				</tr>
 			</table>
 		{/foreach}

--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -108,7 +108,7 @@
 				</tr>
 
 				<tr class="nextras-mail-panel-preview-html tracy-collapsed">
-					<td colspan="2" data-content="{$message|previewHtml}"></td>
+					<td colspan="2" data-src="{link('preview', ['message-id' => $messageId])}"></td>
 				</tr>
 			</table>
 		{/foreach}
@@ -129,22 +129,18 @@
 							var iframe = document.createElement('iframe');
 							preview.appendChild(iframe);
 
-							iframe.contentWindow.document.write(preview.dataset.content);
-							iframe.contentWindow.document.close();
-							delete preview.dataset.content;
-
-							var baseTag = iframe.contentWindow.document.createElement('base');
-							baseTag.target = '_parent';
-							iframe.contentWindow.document.body.appendChild(baseTag);
-
 							var fixHeight = function (ev) {
+								var iframeDocument = iframe.contentWindow.document;
+								var iframeBody = iframeDocument.body || iframeDocument.documentElement;
 								iframe.style.height = 0;
-								iframe.style.height = iframe.contentWindow.document.body.scrollHeight + 'px';
+								iframe.style.height = iframeBody.scrollHeight + 'px';
 								iframe.contentWindow.removeEventListener(ev.type, fixHeight);
 							};
 
 							iframe.contentWindow.addEventListener('load', fixHeight);
 							iframe.contentWindow.addEventListener('resize', fixHeight);
+							iframe.src = preview.dataset.src;
+							delete preview.dataset.src;
 							actions.removeEventListener('tracy-toggle', initHtmlPreview);
 							actions.removeEventListener('click', initHtmlPreview);
 						};

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -147,14 +147,6 @@ class MailPanel implements IBarPanel
 				return $this->decodeBody($part);
 			});
 
-			$this->latte->addFilter('htmlBody', function (MimePart $part): string {
-				if ($part instanceof Message && $part->getHtmlBody() !== '') {
-					return $part->getHtmlBody();
-				}
-
-				return $this->findBodyByContentType($part, 'text/html') ?? '';
-			});
-
 			$this->latte->addFilter('previewHtml', function (MimePart $part): string {
 				$htmlBody = $this->extractHtmlBody($part);
 				if ($htmlBody !== '') {
@@ -210,7 +202,9 @@ class MailPanel implements IBarPanel
 	{
 		if ($this->mimePartPartsProperty === null) {
 			$this->mimePartPartsProperty = new \ReflectionProperty(MimePart::class, 'parts');
-			$this->mimePartPartsProperty->setAccessible(true);
+			if (PHP_VERSION_ID < 80100) {
+				$this->mimePartPartsProperty->setAccessible(true);
+			}
 		}
 
 		$parts = $this->mimePartPartsProperty->getValue($part);

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -12,6 +12,7 @@ use Latte;
 use Nette;
 use Nette\Http;
 use Nette\Mail\Mailer;
+use Nette\Mail\Message;
 use Nette\Mail\MimePart;
 use Nette\Utils\Strings;
 use Tracy\Debugger;
@@ -42,6 +43,9 @@ class MailPanel implements IBarPanel
 
 	/** @var Latte\Engine|NULL */
 	private $latte;
+
+	/** @var \ReflectionProperty|NULL */
+	private $mimePartPartsProperty;
 
 
 	public function __construct(?string $tempDir, Http\IRequest $request, Mailer $mailer, int $messagesLimit = self::DEFAULT_COUNT)
@@ -135,26 +139,100 @@ class MailPanel implements IBarPanel
 			});
 
 			$this->latte->addFilter('plainText', function (MimePart $part) {
-				$ref = new \ReflectionProperty('Nette\Mail\MimePart', 'parts');
-
-				$queue = [$part];
-				for ($i = 0; $i < count($queue); $i++) {
-					/** @var MimePart $subPart */
-					foreach ($ref->getValue($queue[$i]) as $subPart) {
-						$contentType = $subPart->getHeader('Content-Type');
-						if (Strings::startsWith($contentType, 'text/plain') && $subPart->getHeader('Content-Transfer-Encoding') !== 'base64') { // Take first available plain text
-							return $subPart->getBody();
-						} elseif (Strings::startsWith($contentType, 'multipart/alternative')) {
-							$queue[] = $subPart;
-						}
-					}
+				$plainText = $this->findBodyByContentType($part, 'text/plain');
+				if ($plainText !== null) {
+					return $plainText;
 				}
 
-				return $part->getBody();
+				return $this->decodeBody($part);
+			});
+
+			$this->latte->addFilter('htmlBody', function (MimePart $part): string {
+				if ($part instanceof Message && $part->getHtmlBody() !== '') {
+					return $part->getHtmlBody();
+				}
+
+				return $this->findBodyByContentType($part, 'text/html') ?? '';
+			});
+
+			$this->latte->addFilter('previewHtml', function (MimePart $part): string {
+				$htmlBody = $this->extractHtmlBody($part);
+				if ($htmlBody !== '') {
+					return $htmlBody;
+				}
+
+				$plainText = $this->findBodyByContentType($part, 'text/plain') ?? $this->decodeBody($part);
+				return '<!doctype html>'
+					. '<meta charset="utf-8">'
+					. '<style>html,body{margin:0;padding:0;border:none;font-family:sans-serif;font-size:12px;white-space:pre;}body{padding:10px;}</style>'
+					. '<body>' . htmlspecialchars($plainText, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</body>';
 			});
 		}
 
 		return $this->latte;
+	}
+
+
+	private function extractHtmlBody(MimePart $part): string
+	{
+		if ($part instanceof Message && $part->getHtmlBody() !== '') {
+			return $part->getHtmlBody();
+		}
+
+		return $this->findBodyByContentType($part, 'text/html') ?? '';
+	}
+
+
+	private function findBodyByContentType(MimePart $part, string $contentTypePrefix): ?string
+	{
+		$queue = [$part];
+		for ($i = 0; $i < count($queue); $i++) {
+			$currentPart = $queue[$i];
+			$contentType = $currentPart->getHeader('Content-Type');
+			if (is_string($contentType) && Strings::startsWith(strtolower($contentType), $contentTypePrefix)) {
+				return $this->decodeBody($currentPart);
+			}
+
+			/** @var MimePart $subPart */
+			foreach ($this->getMimePartParts($currentPart) as $subPart) {
+				$queue[] = $subPart;
+			}
+		}
+
+		return null;
+	}
+
+
+	/**
+	 * @return MimePart[]
+	 */
+	private function getMimePartParts(MimePart $part): array
+	{
+		if ($this->mimePartPartsProperty === null) {
+			$this->mimePartPartsProperty = new \ReflectionProperty(MimePart::class, 'parts');
+			$this->mimePartPartsProperty->setAccessible(true);
+		}
+
+		$parts = $this->mimePartPartsProperty->getValue($part);
+		return is_array($parts) ? $parts : [];
+	}
+
+
+	private function decodeBody(MimePart $part): string
+	{
+		$body = $part->getBody();
+		$transferEncoding = strtolower((string) $part->getHeader('Content-Transfer-Encoding'));
+
+		if ($transferEncoding === MimePart::EncodingQuotedPrintable) {
+			return quoted_printable_decode($body);
+		}
+
+		if ($transferEncoding === MimePart::EncodingBase64) {
+			$decodedBody = base64_decode($body, true);
+			return is_string($decodedBody) ? $decodedBody : $body;
+		}
+
+		return $body;
 	}
 
 

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -304,6 +304,10 @@ class MailPanel implements IBarPanel
 	{
 		$baseTag = '<base target="_parent">';
 
+		if (preg_match('~<base(?:\s[^>]*)?>~i', $html) === 1) {
+			return $html;
+		}
+
 		if (preg_match('~<head(?:\s[^>]*)?>~i', $html, $match, PREG_OFFSET_CAPTURE) === 1) {
 			$headTag = $match[0][0];
 			$position = $match[0][1] + strlen($headTag);

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -240,7 +240,10 @@ class MailPanel implements IBarPanel
 		$messageId = $this->request->getQuery('nextras-mail-panel-message-id');
 		$attachmentId = $this->request->getQuery('nextras-mail-panel-attachment-id');
 
-		if ($action === 'detail' && is_string($messageId)) {
+		if ($action === 'preview' && is_string($messageId)) {
+			$this->handlePreview($messageId);
+
+		} elseif ($action === 'detail' && is_string($messageId)) {
 			$this->handleDetail($messageId);
 
 		} elseif ($action === 'source' && is_string($messageId)) {
@@ -264,7 +267,18 @@ class MailPanel implements IBarPanel
 		$message = $this->mailer->getMessage($messageId);
 
 		header('Content-Type: text/html');
-		$this->getLatte()->render(__DIR__ . '/MailPanel.body.latte', ['message' => $message]);
+		echo $this->renderMessagePreview($message);
+		exit;
+	}
+
+
+	private function handlePreview(string $messageId): void
+	{
+		assert($this->mailer !== null);
+		$message = $this->mailer->getMessage($messageId);
+
+		header('Content-Type: text/html');
+		echo $this->addParentBaseTarget($this->renderMessagePreview($message));
 		exit;
 	}
 
@@ -277,6 +291,32 @@ class MailPanel implements IBarPanel
 		header('Content-Type: text/plain');
 		echo $message->getEncodedMessage();
 		exit;
+	}
+
+
+	private function renderMessagePreview(MimePart $message): string
+	{
+		return $this->getLatte()->renderToString(__DIR__ . '/MailPanel.body.latte', ['message' => $message]);
+	}
+
+
+	private function addParentBaseTarget(string $html): string
+	{
+		$baseTag = '<base target="_parent">';
+
+		if (preg_match('~<head(?:\s[^>]*)?>~i', $html, $match, PREG_OFFSET_CAPTURE) === 1) {
+			$headTag = $match[0][0];
+			$position = $match[0][1] + strlen($headTag);
+			return substr($html, 0, $position) . $baseTag . substr($html, $position);
+		}
+
+		if (preg_match('~<html(?:\s[^>]*)?>~i', $html, $match, PREG_OFFSET_CAPTURE) === 1) {
+			$htmlTag = $match[0][0];
+			$position = $match[0][1] + strlen($htmlTag);
+			return substr($html, 0, $position) . '<head>' . $baseTag . '</head>' . substr($html, $position);
+		}
+
+		return '<!doctype html><html><head>' . $baseTag . '</head><body>' . $html . '</body></html>';
 	}
 
 

--- a/tests/MailPanelTest.phpt
+++ b/tests/MailPanelTest.phpt
@@ -1,0 +1,152 @@
+<?php declare(strict_types = 1);
+
+use Nette\Http\Request;
+use Nette\Http\UrlScript;
+use Nette\Mail\Message;
+use Nextras\MailPanel\IPersistentMailer;
+use Nextras\MailPanel\MailPanel;
+use Tester\Assert;
+use Tester\Helpers;
+use Tester\TestCase;
+
+require __DIR__ . '/bootstrap.php';
+
+
+class MailPanelTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		Helpers::purge(TEMP_DIR);
+	}
+
+
+	public function testRendersHtmlBodyFromTextHtmlMessageBody(): void
+	{
+		$message = (new Message())
+			->setContentType('text/html', 'UTF-8')
+			->setBody('<h1>Hello from HTML</h1>');
+
+		$output = $this->renderMessageBody($message);
+
+		Assert::contains('<h1>Hello from HTML</h1>', $output);
+		Assert::notContains('&lt;h1&gt;Hello from HTML&lt;/h1&gt;', $output);
+	}
+
+
+	public function testPanelStoresEscapedHtmlPreviewInDataAttribute(): void
+	{
+		$message = (new Message())
+			->setSubject('Panel preview')
+			->setHtmlBody('<h1>Hello from HTML</h1>');
+
+		$panel = $this->createPanel(new ArrayPersistentMailer(['message-id' => $message]));
+		$output = $panel->getPanel();
+
+		Assert::contains('data-content="&lt;h1&gt;Hello from HTML&lt;/h1&gt;"', $output);
+	}
+
+
+	private function renderMessageBody(Message $message): string
+	{
+		$panel = $this->createPanel(new NullPersistentMailer());
+
+		$ref = new ReflectionMethod(MailPanel::class, 'getLatte');
+		$ref->setAccessible(true);
+		$latte = $ref->invoke($panel);
+
+		return $latte->renderToString(__DIR__ . '/../src/MailPanel.body.latte', ['message' => $message]);
+	}
+
+
+	private function createPanel(IPersistentMailer $mailer): MailPanel
+	{
+		return new MailPanel(
+			TEMP_DIR . '/latte',
+			new Request(new UrlScript('http://localhost/index.php')),
+			$mailer,
+		);
+	}
+}
+
+
+class NullPersistentMailer implements IPersistentMailer
+{
+	public function send(Message $message): void
+	{
+	}
+
+
+	public function getMessageCount(): int
+	{
+		return 0;
+	}
+
+
+	public function getMessage(string $messageId): Message
+	{
+		throw new RuntimeException('No messages available.');
+	}
+
+
+	public function getMessages(int $limit): array
+	{
+		return [];
+	}
+
+
+	public function deleteOne(string $messageId): void
+	{
+	}
+
+
+	public function deleteAll(): void
+	{
+	}
+}
+
+
+class ArrayPersistentMailer implements IPersistentMailer
+{
+	/**
+	 * @param Message[] $messages
+	 */
+	public function __construct(
+		private array $messages,
+	) {
+	}
+
+
+	public function send(Message $message): void
+	{
+	}
+
+
+	public function getMessageCount(): int
+	{
+		return count($this->messages);
+	}
+
+
+	public function getMessage(string $messageId): Message
+	{
+		return $this->messages[$messageId];
+	}
+
+
+	public function getMessages(int $limit): array
+	{
+		return array_slice($this->messages, 0, $limit, true);
+	}
+
+
+	public function deleteOne(string $messageId): void
+	{
+	}
+
+
+	public function deleteAll(): void
+	{
+	}
+}
+
+(new MailPanelTest)->run();

--- a/tests/MailPanelTest.phpt
+++ b/tests/MailPanelTest.phpt
@@ -45,6 +45,19 @@ class MailPanelTest extends TestCase
 		Assert::contains('data-src="index.php?nextras-mail-panel-action=preview&amp;nextras-mail-panel-message-id=message-id"', $output);
 	}
 
+
+	public function testPreviewPreservesExistingBaseTag(): void
+	{
+		$message = (new Message())
+			->setSubject('Panel preview')
+			->setHtmlBody('<!doctype html><html><head><base href="https://example.com/assets/"><style>body{color:#000;}</style></head><body><img src="logo.png"></body></html>');
+
+		$output = $this->renderPreviewHtml($message);
+
+		Assert::contains('<base href="https://example.com/assets/">', $output);
+		Assert::notContains('<base target="_parent">', $output);
+	}
+
 	private function renderMessageBody(Message $message): string
 	{
 		$panel = $this->createPanel(new NullPersistentMailer());
@@ -54,6 +67,19 @@ class MailPanelTest extends TestCase
 		$latte = $ref->invoke($panel);
 
 		return $latte->renderToString(__DIR__ . '/../src/MailPanel.body.latte', ['message' => $message]);
+	}
+
+
+	private function renderPreviewHtml(Message $message): string
+	{
+		$panel = $this->createPanel(new NullPersistentMailer());
+
+		$renderMessagePreview = new ReflectionMethod(MailPanel::class, 'renderMessagePreview');
+		$renderMessagePreview->setAccessible(true);
+		$addParentBaseTarget = new ReflectionMethod(MailPanel::class, 'addParentBaseTarget');
+		$addParentBaseTarget->setAccessible(true);
+
+		return $addParentBaseTarget->invoke($panel, $renderMessagePreview->invoke($panel, $message));
 	}
 
 

--- a/tests/MailPanelTest.phpt
+++ b/tests/MailPanelTest.phpt
@@ -33,7 +33,7 @@ class MailPanelTest extends TestCase
 	}
 
 
-	public function testPanelStoresEscapedHtmlPreviewInDataAttribute(): void
+	public function testPanelStoresPreviewEndpointInDataAttribute(): void
 	{
 		$message = (new Message())
 			->setSubject('Panel preview')
@@ -42,9 +42,8 @@ class MailPanelTest extends TestCase
 		$panel = $this->createPanel(new ArrayPersistentMailer(['message-id' => $message]));
 		$output = $panel->getPanel();
 
-		Assert::contains('data-content="&lt;h1&gt;Hello from HTML&lt;/h1&gt;"', $output);
+		Assert::contains('data-src="index.php?nextras-mail-panel-action=preview&amp;nextras-mail-panel-message-id=message-id"', $output);
 	}
-
 
 	private function renderMessageBody(Message $message): string
 	{


### PR DESCRIPTION
Fixes #47.

## Summary

- load `Preview HTML` through a dedicated server-side preview endpoint
- stop writing preview HTML into the iframe document client-side
- keep HTML preview rendering on the same server-side path used for rendered message previews
- update the regression test to assert the preview endpoint contract

## Why

The regression was not in MIME parsing itself. The extracted HTML was correct, but the Tracy panel preview still reconstructed the iframe document client-side. That was fragile for full HTML emails containing `<head>` and `<style>` and could render parts of the document as source text instead of HTML.