### PR TITLE
Fix HTML preview rendering in Tracy panel

### DIFF
--- a/src/MailPanel.body.latte
+++ b/src/MailPanel.body.latte
@@ -1,2 +1,2 @@
-{* Little magic here. Create iframe and then render message into it (needed because HTML messages) *}
+{* Render a standalone HTML preview document or fragment. *}
 {$message|previewHtml|noescape}

--- a/src/MailPanel.latte
+++ b/src/MailPanel.latte
@@ -108,7 +108,7 @@
 				</tr>
 
 				<tr class="nextras-mail-panel-preview-html tracy-collapsed">
-					<td colspan="2" data-content="{$message|previewHtml}"></td>
+					<td colspan="2" data-src="{link('preview', ['message-id' => $messageId])}"></td>
 				</tr>
 			</table>
 		{/foreach}
@@ -129,22 +129,18 @@
 							var iframe = document.createElement('iframe');
 							preview.appendChild(iframe);
 
-							iframe.contentWindow.document.write(preview.dataset.content);
-							iframe.contentWindow.document.close();
-							delete preview.dataset.content;
-
-							var baseTag = iframe.contentWindow.document.createElement('base');
-							baseTag.target = '_parent';
-							iframe.contentWindow.document.body.appendChild(baseTag);
-
 							var fixHeight = function (ev) {
+								var iframeDocument = iframe.contentWindow.document;
+								var iframeBody = iframeDocument.body || iframeDocument.documentElement;
 								iframe.style.height = 0;
-								iframe.style.height = iframe.contentWindow.document.body.scrollHeight + 'px';
+								iframe.style.height = iframeBody.scrollHeight + 'px';
 								iframe.contentWindow.removeEventListener(ev.type, fixHeight);
 							};
 
 							iframe.contentWindow.addEventListener('load', fixHeight);
 							iframe.contentWindow.addEventListener('resize', fixHeight);
+							iframe.src = preview.dataset.src;
+							delete preview.dataset.src;
 							actions.removeEventListener('tracy-toggle', initHtmlPreview);
 							actions.removeEventListener('click', initHtmlPreview);
 						};

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -304,6 +304,10 @@ class MailPanel implements IBarPanel
 	{
 		$baseTag = '<base target="_parent">';
 
+		if (preg_match('~<base(?:\s[^>]*)?>~i', $html) === 1) {
+			return $html;
+		}
+
 		if (preg_match('~<head(?:\s[^>]*)?>~i', $html, $match, PREG_OFFSET_CAPTURE) === 1) {
 			$headTag = $match[0][0];
 			$position = $match[0][1] + strlen($headTag);

--- a/src/MailPanel.php
+++ b/src/MailPanel.php
@@ -240,7 +240,10 @@ class MailPanel implements IBarPanel
 		$messageId = $this->request->getQuery('nextras-mail-panel-message-id');
 		$attachmentId = $this->request->getQuery('nextras-mail-panel-attachment-id');
 
-		if ($action === 'detail' && is_string($messageId)) {
+		if ($action === 'preview' && is_string($messageId)) {
+			$this->handlePreview($messageId);
+
+		} elseif ($action === 'detail' && is_string($messageId)) {
 			$this->handleDetail($messageId);
 
 		} elseif ($action === 'source' && is_string($messageId)) {
@@ -264,7 +267,18 @@ class MailPanel implements IBarPanel
 		$message = $this->mailer->getMessage($messageId);
 
 		header('Content-Type: text/html');
-		$this->getLatte()->render(__DIR__ . '/MailPanel.body.latte', ['message' => $message]);
+		echo $this->renderMessagePreview($message);
+		exit;
+	}
+
+
+	private function handlePreview(string $messageId): void
+	{
+		assert($this->mailer !== null);
+		$message = $this->mailer->getMessage($messageId);
+
+		header('Content-Type: text/html');
+		echo $this->addParentBaseTarget($this->renderMessagePreview($message));
 		exit;
 	}
 
@@ -277,6 +291,32 @@ class MailPanel implements IBarPanel
 		header('Content-Type: text/plain');
 		echo $message->getEncodedMessage();
 		exit;
+	}
+
+
+	private function renderMessagePreview(MimePart $message): string
+	{
+		return $this->getLatte()->renderToString(__DIR__ . '/MailPanel.body.latte', ['message' => $message]);
+	}
+
+
+	private function addParentBaseTarget(string $html): string
+	{
+		$baseTag = '<base target="_parent">';
+
+		if (preg_match('~<head(?:\s[^>]*)?>~i', $html, $match, PREG_OFFSET_CAPTURE) === 1) {
+			$headTag = $match[0][0];
+			$position = $match[0][1] + strlen($headTag);
+			return substr($html, 0, $position) . $baseTag . substr($html, $position);
+		}
+
+		if (preg_match('~<html(?:\s[^>]*)?>~i', $html, $match, PREG_OFFSET_CAPTURE) === 1) {
+			$htmlTag = $match[0][0];
+			$position = $match[0][1] + strlen($htmlTag);
+			return substr($html, 0, $position) . '<head>' . $baseTag . '</head>' . substr($html, $position);
+		}
+
+		return '<!doctype html><html><head>' . $baseTag . '</head><body>' . $html . '</body></html>';
 	}
 
 

--- a/tests/MailPanelTest.phpt
+++ b/tests/MailPanelTest.phpt
@@ -45,6 +45,19 @@ class MailPanelTest extends TestCase
 		Assert::contains('data-src="index.php?nextras-mail-panel-action=preview&amp;nextras-mail-panel-message-id=message-id"', $output);
 	}
 
+
+	public function testPreviewPreservesExistingBaseTag(): void
+	{
+		$message = (new Message())
+			->setSubject('Panel preview')
+			->setHtmlBody('<!doctype html><html><head><base href="https://example.com/assets/"><style>body{color:#000;}</style></head><body><img src="logo.png"></body></html>');
+
+		$output = $this->renderPreviewHtml($message);
+
+		Assert::contains('<base href="https://example.com/assets/">', $output);
+		Assert::notContains('<base target="_parent">', $output);
+	}
+
 	private function renderMessageBody(Message $message): string
 	{
 		$panel = $this->createPanel(new NullPersistentMailer());
@@ -54,6 +67,19 @@ class MailPanelTest extends TestCase
 		$latte = $ref->invoke($panel);
 
 		return $latte->renderToString(__DIR__ . '/../src/MailPanel.body.latte', ['message' => $message]);
+	}
+
+
+	private function renderPreviewHtml(Message $message): string
+	{
+		$panel = $this->createPanel(new NullPersistentMailer());
+
+		$renderMessagePreview = new ReflectionMethod(MailPanel::class, 'renderMessagePreview');
+		$renderMessagePreview->setAccessible(true);
+		$addParentBaseTarget = new ReflectionMethod(MailPanel::class, 'addParentBaseTarget');
+		$addParentBaseTarget->setAccessible(true);
+
+		return $addParentBaseTarget->invoke($panel, $renderMessagePreview->invoke($panel, $message));
 	}
 
 

--- a/tests/MailPanelTest.phpt
+++ b/tests/MailPanelTest.phpt
@@ -33,7 +33,7 @@ class MailPanelTest extends TestCase
 	}
 
 
-	public function testPanelStoresEscapedHtmlPreviewInDataAttribute(): void
+	public function testPanelStoresPreviewEndpointInDataAttribute(): void
 	{
 		$message = (new Message())
 			->setSubject('Panel preview')
@@ -42,9 +42,8 @@ class MailPanelTest extends TestCase
 		$panel = $this->createPanel(new ArrayPersistentMailer(['message-id' => $message]));
 		$output = $panel->getPanel();
 
-		Assert::contains('data-content="&lt;h1&gt;Hello from HTML&lt;/h1&gt;"', $output);
+		Assert::contains('data-src="index.php?nextras-mail-panel-action=preview&amp;nextras-mail-panel-message-id=message-id"', $output);
 	}
-
 
 	private function renderMessageBody(Message $message): string
 	{


### PR DESCRIPTION
Fixes #47.

## Summary

- load `Preview HTML` through a dedicated server-side preview endpoint
- stop writing preview HTML into the iframe document client-side
- keep HTML preview rendering on the same server-side path used for rendered message previews
- avoid injecting a new `<base>` tag when the email already defines one
- update tests for the new preview endpoint behavior

## Why

The regression does not seem to be in MIME extraction itself. The extracted HTML is correct, but the Tracy panel preview was still reconstructing the iframe document client-side, which is fragile for full HTML emails containing `<head>` and `<style>`.
