### PR TITLE
Fix PHP 8.5 setAccessible() deprecations

### DIFF
--- a/src/FileMailer.php
+++ b/src/FileMailer.php
@@ -40,7 +40,9 @@ class FileMailer implements IPersistentMailer
 	{
 		// get message with generated html instead of set FileTemplate etc
 		$ref = new \ReflectionMethod('Nette\Mail\Message', 'build');
-		$ref->setAccessible(true);
+		if (PHP_VERSION_ID < 80100) {
+			$ref->setAccessible(true);
+		}
 
 		/** @var Message */
 		$builtMessage = $ref->invoke($message);

--- a/tests/MailPanelTest.phpt
+++ b/tests/MailPanelTest.phpt
@@ -51,7 +51,9 @@ class MailPanelTest extends TestCase
 		$panel = $this->createPanel(new NullPersistentMailer());
 
 		$ref = new ReflectionMethod(MailPanel::class, 'getLatte');
-		$ref->setAccessible(true);
+		if (PHP_VERSION_ID < 80100) {
+			$ref->setAccessible(true);
+		}
 		$latte = $ref->invoke($panel);
 
 		return $latte->renderToString(__DIR__ . '/../src/MailPanel.body.latte', ['message' => $message]);


### PR DESCRIPTION
PHP 8.5 deprecates `ReflectionMethod::setAccessible()` / `ReflectionProperty::setAccessible()` since they've been no-ops since 8.1. This wraps the two remaining unguarded calls in `if (PHP_VERSION_ID < 80100)` to silence the warning while keeping PHP 7.1–8.0 support (per composer.json).

Changes:
- `src/FileMailer.php` — guarded
- `tests/MailPanelTest.phpt` — guarded
- `src/MailPanel.php:206` was already guarded correctly, left alone

#45 did the same thing for one call in `MailPanel.php` but missed these two.